### PR TITLE
mtp+deepep  shape mismatch bug fix

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -61,6 +61,7 @@ class _LayerModeComputationContext:
     layer_id: int
     is_layer_sparse: bool
     is_previous_layer_sparse: Optional[bool]
+    is_nextn: Optional[bool]
 
     def previous_layer(self):
         assert self.is_previous_layer_sparse is not None
@@ -69,6 +70,7 @@ class _LayerModeComputationContext:
             is_layer_sparse=self.is_previous_layer_sparse,
             is_previous_layer_sparse=None,
             num_layers=self.num_layers,
+            is_nextn=self.is_nextn
         )
 
 
@@ -103,7 +105,7 @@ class LayerScatterModes:
         if context.is_layer_sparse:
             return (
                 ScatterMode.SCATTERED
-                if global_server_args_dict["enable_deepep_moe"]
+                if global_server_args_dict["enable_deepep_moe"] and not context.is_nextn
                 else ScatterMode.FULL
             )
         else:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1431,6 +1431,7 @@ class DeepseekV2DecoderLayer(nn.Module):
             num_layers=config.num_hidden_layers,
             is_layer_sparse=self.is_layer_sparse,
             is_previous_layer_sparse=is_previous_layer_sparse,
+            is_nextn=is_nextn
         )
 
         if self.is_layer_sparse:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Support mtp+deepep. In previous versions, if deepseek turns on *mtp* and *deepep*, an error will occur in the *select_top_k_tokens* function in 

> python/sglang/srt/speculative/eagle_utils.py. 

The reason for the error is: in the following code, the shapes of b of scores and topk_p are different.

```python
expand_scores = torch.mul(
    scores.unsqueeze(2), topk_p.reshape(-1, topk, topk)
)  # (b, topk, 1) x (b, topk ,topk) -> (b, topk, topk)
```

After tracing back, it was because *DeepseekV2DecoderLayer* was run once in *DeepseekNextN*, and its settings were not considered to be run separately. Therefore, *_scatter_hidden_states_and_residual* was triggered in *self.layer_communicator.prepare_mlp*, causing the shape of tensor to change, causing the previous bug.

## Modifications

Pass the *is_nextn* status to *LayerScatterModes*. When *enable_deepep_moe*, it needs to be not *is_nextn* to enter *ScatterMode.SCATTERED* mode


## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
